### PR TITLE
To get all public collections for the Admin manage collection page

### DIFF
--- a/bnd-workspace/de.fraunhofer.abm.app/src/de/fraunhofer/abm/app/controllers/AdminManageCollectionController.java
+++ b/bnd-workspace/de.fraunhofer.abm.app/src/de/fraunhofer/abm/app/controllers/AdminManageCollectionController.java
@@ -1,0 +1,59 @@
+package de.fraunhofer.abm.app.controllers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.useradmin.UserAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.fraunhofer.abm.app.auth.Authorizer;
+import de.fraunhofer.abm.collection.dao.CollectionDao;
+import de.fraunhofer.abm.domain.CollectionDTO;
+import osgi.enroute.configurer.api.RequireConfigurerExtender;
+import osgi.enroute.rest.api.REST;
+import osgi.enroute.rest.api.RESTRequest;
+import osgi.enroute.webserver.capabilities.RequireWebServerExtender;
+
+@RequireWebServerExtender
+@RequireConfigurerExtender
+@Component(name = "de.fraunhofer.abm.rest.managecollection")
+public class AdminManageCollectionController extends AbstractController implements REST {
+
+	private static final transient Logger logger = LoggerFactory.getLogger(CollectionController.class);
+
+	@Reference
+	private CollectionDao collectionDao;
+
+	@Reference
+	private UserAdmin userAdmin;
+
+	@Reference
+	private Authorizer authorizer;
+
+
+
+
+	interface AccountRequest extends RESTRequest {
+		Map<String, String> _body();
+	}
+
+	public List<CollectionDTO> getManagecollection(RESTRequest rr) throws Exception {
+		authorizer.requireRole("UserAdmin");
+		List<CollectionDTO> result = Collections.emptyList();
+        try {
+         result = collectionDao.findCollections();
+        } catch (Exception e) {
+        	logger.info("Exception");
+        }
+        return result;
+	}
+
+	@Override
+	Logger getLogger() {
+		return logger;	
+		}
+}

--- a/bnd-workspace/de.fraunhofer.abm.collection.dao.jpa/src/de/fraunhofer/abm/collection/dao/jpa/JpaCollectionDao.java
+++ b/bnd-workspace/de.fraunhofer.abm.collection.dao.jpa/src/de/fraunhofer/abm/collection/dao/jpa/JpaCollectionDao.java
@@ -170,6 +170,17 @@ public class JpaCollectionDao extends AbstractJpaDao implements CollectionDao {
             return result.toDTO();
         });
     }
+    
+    @Override
+    public List<CollectionDTO> findCollections(){
+    	//Collections returned for manage collections for admin
+    	return transactionControl.notSupported(() -> {
+            TypedQuery<JpaCollection> query = em.createQuery("SELECT c FROM collection c WHERE c.privateStatus = 0 ORDER BY c.creation_date ASC", JpaCollection.class);
+            query.setMaxResults(30);
+            List<JpaCollection> jpaList = query.getResultList();
+            return jpaList.stream().map(JpaCollection::toDTO).collect(Collectors.toList());
+        });
+    }
 
     @Override
     protected EntityManager getEntityManager() {

--- a/bnd-workspace/de.fraunhofer.abm.collection.dao/src/de/fraunhofer/abm/collection/dao/CollectionDao.java
+++ b/bnd-workspace/de.fraunhofer.abm.collection.dao/src/de/fraunhofer/abm/collection/dao/CollectionDao.java
@@ -17,4 +17,5 @@ public interface CollectionDao {
     public void save(CollectionDTO collection);
     public void update(CollectionDTO collection);
     public void delete(String id);
+	public List<CollectionDTO> findCollections();
 }

--- a/bnd-workspace/de.fraunhofer.abm.test.http/src/de/fraunhofer/abm/test/http/AdminManageCollectionControllerTest.java
+++ b/bnd-workspace/de.fraunhofer.abm.test.http/src/de/fraunhofer/abm/test/http/AdminManageCollectionControllerTest.java
@@ -44,7 +44,7 @@ import de.fraunhofer.abm.http.client.HttpResponse;
 
 		private void testGetCollection() throws IOException {
 			Map<String, String> headers = login();
-			String uri = baseUri + "/rest/managecollection?user=" + "test5";
+			String uri = baseUri + "/rest/managecollection";
 	    	
 	        String collections = HttpUtils.get(uri, headers, charset); 
 	        JSONArray array = new JSONArray(collections);

--- a/bnd-workspace/de.fraunhofer.abm.test.http/src/de/fraunhofer/abm/test/http/AdminManageCollectionControllerTest.java
+++ b/bnd-workspace/de.fraunhofer.abm.test.http/src/de/fraunhofer/abm/test/http/AdminManageCollectionControllerTest.java
@@ -1,0 +1,59 @@
+
+package de.fraunhofer.abm.test.http;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import de.fraunhofer.abm.http.client.Base64.InputStream;
+import de.fraunhofer.abm.http.client.HttpResponse;
+	import de.fraunhofer.abm.http.client.HttpUtils;
+	public class AdminManageCollectionControllerTest extends AbstractHttpTest {
+	    @Test
+	    public void testCollectionstatus() throws IOException {
+	    	final int num200 = 200;
+	        // send a login request
+	        Map<String, String> headers = new HashMap<>();
+	        headers.put("Content-Type", "application/json;charset=UTF-8");
+	        String uri = baseUri + "/rest/login";
+	        String payload = "{\"username\": \""+USER+"\", \"password\": \""+PASSWORD+"\"}";
+	        HttpResponse response = HttpUtils.post(uri, headers, payload.getBytes(), charset);
+	        Assert.assertEquals(num200, response.getResponseCode());
+	        String sessionCookie = HttpUtils.getHeaderField(response.getHeader(), "Set-Cookie");
+	        Assert.assertTrue(sessionCookie.contains("JSESSIONID"));
+	        // try to get a secured resource
+	        headers.put("Cookie", sessionCookie);
+	        
+	        testGetCollection();
+	       
+
+	    }	
+	    protected Map<String, String> login() throws IOException {
+	        login(USER, PASSWORD);
+	        Map<String, String> headers = HttpUtils.createFirefoxHeader();
+	        addSessionCookie(headers);
+	        return headers;
+	    }
+	   
+
+		private void testGetCollection() throws IOException {
+			Map<String, String> headers = login();
+			String uri = baseUri + "/rest/managecollection?user=" + "test5";
+	    	
+	        String collections = HttpUtils.get(uri, headers, charset); 
+	        JSONArray array = new JSONArray(collections);
+	        Assert.assertNotNull(array);
+	    
+	        
+		}
+		
+
+	
+}
+	


### PR DESCRIPTION
Functionality : To get all the public collections of the users for the UserAdmin
--> We needed an extra controller because for the normal users, only the active public collections will be viewed, but the "UserAdmin" will be able to view all the public collections which are active as well as deactive
Controller added : AdminManageCollectionController.java
Testcase added : AdminManageCollectionControllerTest.java
Issue link: https://github.com/ABenchM/abm/issues/219