### PR TITLE
Derive version API changes

### DIFF
--- a/bnd-workspace/de.fraunhofer.abm.app/src/de/fraunhofer/abm/app/controllers/VersionController.java
+++ b/bnd-workspace/de.fraunhofer.abm.app/src/de/fraunhofer/abm/app/controllers/VersionController.java
@@ -106,7 +106,9 @@ public class VersionController extends AbstractController implements REST {
         ensureUserIsOwner(authorizer, collectionDao, version);
 
         version.comment = "Derived from version " + version.number + ": " + version.comment;
+        version.derivedFrom = version.id;
         version.id = UUID.randomUUID().toString();
+        version.name = "derived new version";
         version.creationDate = new Date();
         version.frozen = false;
         for (CommitDTO commit : version.commits) {

--- a/bnd-workspace/de.fraunhofer.abm.app/src/de/fraunhofer/abm/app/controllers/VersionController.java
+++ b/bnd-workspace/de.fraunhofer.abm.app/src/de/fraunhofer/abm/app/controllers/VersionController.java
@@ -111,6 +111,7 @@ public class VersionController extends AbstractController implements REST {
         version.id = UUID.randomUUID().toString();
         version.creationDate = new Date();
         version.frozen = false;
+        version.privateStatus = true;
         for (CommitDTO commit : version.commits) {
             commit.id = UUID.randomUUID().toString();
         }

--- a/bnd-workspace/de.fraunhofer.abm.app/src/de/fraunhofer/abm/app/controllers/VersionController.java
+++ b/bnd-workspace/de.fraunhofer.abm.app/src/de/fraunhofer/abm/app/controllers/VersionController.java
@@ -107,8 +107,8 @@ public class VersionController extends AbstractController implements REST {
 
         version.comment = "Derived from version " + version.number + ": " + version.comment;
         version.derivedFrom = version.id;
+        version.name = "derived new version from "+version.id;
         version.id = UUID.randomUUID().toString();
-        version.name = "derived new version";
         version.creationDate = new Date();
         version.frozen = false;
         for (CommitDTO commit : version.commits) {

--- a/bnd-workspace/de.fraunhofer.abm.collection.dao.jpa/src/de/fraunhofer/abm/collection/dao/jpa/JpaVersion.java
+++ b/bnd-workspace/de.fraunhofer.abm.collection.dao.jpa/src/de/fraunhofer/abm/collection/dao/jpa/JpaVersion.java
@@ -23,6 +23,12 @@ public class JpaVersion {
     @Id
     @Column
     public String id;
+    
+    @Column
+    public String name;
+    
+    @Column
+    public String derivedFrom;
 
     @Column(name="creation_date")
     public Date creationDate;
@@ -54,6 +60,8 @@ public class JpaVersion {
         version.id = dto.id;
         version.creationDate = dto.creationDate;
         version.number = dto.number;
+        version.name = dto.name;
+        version.derivedFrom = dto.derivedFrom;
         version.comment = dto.comment;
         version.frozen = dto.frozen;
         version.privateStatus = dto.privateStatus;

--- a/bnd-workspace/de.fraunhofer.abm.collection.dao.jpa/src/de/fraunhofer/abm/collection/dao/jpa/JpaVersionDao.java
+++ b/bnd-workspace/de.fraunhofer.abm.collection.dao.jpa/src/de/fraunhofer/abm/collection/dao/jpa/JpaVersionDao.java
@@ -73,7 +73,9 @@ public class JpaVersionDao extends AbstractJpaDao implements VersionDao {
             jpaVersion.frozen = version.frozen;
             jpaVersion.privateStatus = version.privateStatus;
             jpaVersion.filtered = version.filtered;
-
+        	jpaVersion.name = version.name;
+        	jpaVersion.derivedFrom = version.derivedFrom;
+            
             Map<String, CommitDTO> commits = version.commits.stream()
                     .collect(Collectors.toMap(c -> c.id, Function.identity()));
 

--- a/bnd-workspace/de.fraunhofer.abm.domain/src/de/fraunhofer/abm/domain/VersionDTO.java
+++ b/bnd-workspace/de.fraunhofer.abm.domain/src/de/fraunhofer/abm/domain/VersionDTO.java
@@ -6,6 +6,8 @@ import java.util.List;
 public class VersionDTO {
 
     public String id;
+    public String name;
+    public String derivedFrom;
     public String collectionId;
     public List<CommitDTO> commits;
     public int number;

--- a/docs/abm.sql
+++ b/docs/abm.sql
@@ -61,6 +61,8 @@ CREATE TABLE `version` (
   `collection_id` varchar(255) DEFAULT NULL,
   `privateStatus` tinyint(4) DEFAULT '0',
   `filtered` bit(1) DEFAULT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `derivedFrom` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `FKhwyps0yuo2dvxmfjyp34odxdk` (`collection_id`),
   CONSTRAINT `FKhwyps0yuo2dvxmfjyp34odxdk` FOREIGN KEY (`collection_id`) REFERENCES `collection` (`id`)


### PR DESCRIPTION
Derive new version API

Functionalities:
The derived version should always be private.
It should have an id of the previous version from which it's derived along with the name of the newly derived version.

Issue:  [https://github.com/ABenchM/abm/issues/298](https://github.com/ABenchM/abm/issues/298)

Derive a new version now saves a name for that version and id of the version from which it is derived from.

Database changes: 
2 new columns in version table, 1. name and 2. derivedFrom (  to store the id of prev version )

Test class: the Same VersionControllerTest is used since it's a modification in existing API. 

deriveVersion inside post version API is modified.

new column name and deriveFrom is added to save the name and ID of the previous version.