### PR TITLE
Fix for Issue of getting all versions in collection

### DIFF
--- a/bnd-workspace/de.fraunhofer.abm.collection.dao.jpa/src/de/fraunhofer/abm/collection/dao/jpa/JpaCollectionDao.java
+++ b/bnd-workspace/de.fraunhofer.abm.collection.dao.jpa/src/de/fraunhofer/abm/collection/dao/jpa/JpaCollectionDao.java
@@ -89,11 +89,19 @@ public class JpaCollectionDao extends AbstractJpaDao implements CollectionDao {
     public CollectionDTO getVersionDetails(String versionId) {
 
         return transactionControl.notSupported(() -> {
-        	TypedQuery<JpaCollection> query = em.createQuery("SELECT c FROM collection c, version v WHERE c.id = v.collection.id AND c.isActive = 1 AND v.id = :versionId", JpaCollection.class);
-            query.setParameter("versionId", versionId);
+        	TypedQuery<JpaCollection> queryC = em.createQuery("SELECT c FROM collection c, version v WHERE c.id = v.collection.id AND c.isActive = 1 AND v.id = :versionId", JpaCollection.class);
+            queryC.setParameter("versionId", versionId);
+            TypedQuery<JpaVersion> queryV = em.createQuery("SELECT v FROM version v WHERE v.id = :versionId", JpaVersion.class);
+            queryV.setParameter("versionId", versionId);
             try {
-            	 JpaCollection result = query.getSingleResult();	
-            	 return result.toDTO();
+            	 JpaCollection resultC = queryC.getSingleResult();
+            	 JpaVersion resultV = queryV.getSingleResult();
+            	 CollectionDTO resultC_DTO = resultC.toDTO();
+            	 VersionDTO resultV_DTO = resultV.toDTO();
+            	 List<VersionDTO> versions = new ArrayList<VersionDTO>();
+            	 versions.add(resultV_DTO);
+            	 resultC_DTO.versions = versions;
+            	 return resultC_DTO;
             } catch (NoResultException e) {
              return null;
             }

--- a/bnd-workspace/de.fraunhofer.abm.test.http/src/de/fraunhofer/abm/test/http/CollectionControllerTest.java
+++ b/bnd-workspace/de.fraunhofer.abm.test.http/src/de/fraunhofer/abm/test/http/CollectionControllerTest.java
@@ -176,6 +176,8 @@ public class CollectionControllerTest extends AbstractHttpTest {
         JSONObject obj = new JSONObject(result);
         Assert.assertNotNull(result);
         Assert.assertEquals(id, obj.getString("id"));
+        JSONArray newversionAray = collection.getJSONArray("versions");
+        Assert.assertEquals(1, newversionAray.length());
         Assert.assertEquals("abc", obj.getString("name"));
         Assert.assertEquals("def", obj.getString("description"));
 
@@ -355,4 +357,5 @@ public class CollectionControllerTest extends AbstractHttpTest {
         response = HttpUtils.delete(uri, headers, charset);
         Assert.assertEquals(NUM200, response.getResponseCode());
     }
+    
 }


### PR DESCRIPTION
Fix for Issue of getting all versions in collection even after giving version id as parameter
PR: https://github.com/ABenchM/abm/pull/328
Issue : https://github.com/ABenchM/abm/issues/299
 

Earlier in versions all the versions of the corresponding collection was returned in the list. Only the versionId passed needs to be returned.

Code changes in below files only.
JpaCollectionDao.java
CollectionControllerTest.java